### PR TITLE
Redirect / instead of serving chat.html that generates an internal error

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,5 +1,5 @@
 from gevent import monkey; monkey.patch_all()
-from flask import Flask, request, send_file
+from flask import Flask, request, send_file, redirect
 
 from socketio import socketio_manage
 from socketio.namespace import BaseNamespace
@@ -26,7 +26,7 @@ class ChatNamespace(BaseNamespace, RoomsMixin, BroadcastMixin):
 app = Flask(__name__)
 @app.route('/')
 def index():
-    return send_file('chat.html')
+    return redirect('/chat.html')
 
 @app.route("/socket.io/<path:path>")
 def run_socketio(path):
@@ -43,4 +43,4 @@ if __name__ == '__main__':
     from socketio.server import SocketIOServer
     SocketIOServer(('0.0.0.0', 8080), app,
         namespace="socket.io", policy_server=False).serve_forever()
-    
+


### PR DESCRIPTION
I had that before the small patch :
⚫  gbin@sal flask-gevent-socketio-chat % python server.py 
Listening on http://localhost:8080
DEPRECATION WARNING: use resource instead of namespace
Traceback (most recent call last):
  File "/usr/lib64/python2.7/site-packages/gevent/pywsgi.py", line 438, in handle_one_response
    self.run_application()
  File "/usr/lib64/python2.7/site-packages/gevent/pywsgi.py", line 424, in run_application
    self.result = self.application(self.environ, self.start_response)
  File "/usr/lib64/python2.7/site-packages/werkzeug/wsgi.py", line 411, in **call**
    return self.app(environ, start_response)
  File "/usr/lib64/python2.7/site-packages/flask/app.py", line 1701, in **call**
    return self.wsgi_app(environ, start_response)
  File "/usr/lib64/python2.7/site-packages/flask/app.py", line 1689, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/usr/lib64/python2.7/site-packages/flask/app.py", line 1687, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/lib64/python2.7/site-packages/flask/app.py", line 1360, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/lib64/python2.7/site-packages/flask/app.py", line 1358, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/lib64/python2.7/site-packages/flask/app.py", line 1344, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "server.py", line 29, in index
    return send_file('chat.html')
  File "/usr/lib64/python2.7/site-packages/flask/helpers.py", line 568, in send_file
    file = open(filename, 'rb')
IOError: [Errno 2] No such file or directory: '/home/gbin/projects/flask-gevent-socketio-chat/chat.html'
<SocketIOServer fileno=3 address=0.0.0.0:8080>: Failed to handle request:
  request = GET / HTTP/1.1 from ('127.0.0.1', 40202)
  application = <werkzeug.wsgi.SharedDataMiddleware object at 0x22d8190>
